### PR TITLE
chore: fix linter badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # automatic-contrib-prs
 
-[![.github/workflows/linter.yml](https://github.com/github/automatic-contrib-prs/actions/workflows/linter.yml/badge.svg)](https://github.com/github/automatic-contrib-prs/actions/workflows/linter.yml)
+[![.github/workflows/linter.yml](https://github.com/github/automatic-contrib-prs/actions/workflows/super-linter.yml/badge.svg)](https://github.com/github/automatic-contrib-prs/actions/workflows/super-linter.yml)
 [![CodeQL](https://github.com/github/automatic-contrib-prs/actions/workflows/codeql.yml/badge.svg)](https://github.com/github/automatic-contrib-prs/actions/workflows/codeql.yml)
 [![Docker Image CI](https://github.com/github/automatic-contrib-prs/actions/workflows/docker-image.yml/badge.svg)](https://github.com/github/automatic-contrib-prs/actions/workflows/docker-image.yml)
 


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes

I renamed the workflow from linter.yml to super-linter.yml in #43, forgot to update the badge

### Current

![Screenshot 2024-04-08 at 1 00 17 PM](https://github.com/github/automatic-contrib-prs/assets/35014/0c7c34fd-1a36-473f-acb6-131fa3e3f5cb)

### After

![Screenshot 2024-04-08 at 1 00 43 PM](https://github.com/github/automatic-contrib-prs/assets/35014/cd4c6b9d-674c-4138-af6f-e6b467d2dc20)


## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
