### PR TITLE
chore: pin shas in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2
 #checkov:skip=CKV_DOCKER_3
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:e3ae8cf03c4f0abbfef13a8147478a7cd92798a94fa729a36a185d9106cbae32
 
 WORKDIR /action/workspace
 COPY requirements.txt CONTRIBUTING-template.md open_contrib_pr.py /action/workspace/


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
The base image of the Dockerfile has been updated to use a specific version of the python:3.12-slim image. This is done by referencing the image's SHA256 digest, which ensures that the same image is always used, increasing the reproducibility and security of the Docker build.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
